### PR TITLE
Add reset helpers for Dots and Boxes board

### DIFF
--- a/src/dots/Box.java
+++ b/src/dots/Box.java
@@ -18,4 +18,8 @@ public final class Box {
         if (!hasOwner() && isClosed()) { owner = p; return true; }
         return false;
     }
+
+    public void reset() {
+        owner = null;
+    }
 }

--- a/src/dots/DotsBoard.java
+++ b/src/dots/DotsBoard.java
@@ -20,11 +20,21 @@ public final class DotsBoard extends Board {
     }
 
     @Override public void reset() {
-        // Edges “owner = null”; Boxes “owner = null”
-        for (Edge[] row: horiz) for (Edge e: row) try { if (e.owner()!=null) { // reflectively?
-        } } catch(Exception ignore){}
-        // Simpler: rebuild board for reset (safe & clear):
-        // (Optional: leave as no-op for A2; typical flows don’t call reset mid-game.)
+        for (Edge[] row : horiz) {
+            for (Edge edge : row) {
+                edge.reset();
+            }
+        }
+        for (Edge[] row : vert) {
+            for (Edge edge : row) {
+                edge.reset();
+            }
+        }
+        for (Box[] row : boxes) {
+            for (Box box : row) {
+                box.reset();
+            }
+        }
     }
 
     public Edge getEdge(int r, int c, Edge.Orient o) {

--- a/src/dots/Edge.java
+++ b/src/dots/Edge.java
@@ -18,4 +18,8 @@ public final class Edge {
         if (!isFree()) throw new IllegalStateException("Edge already claimed");
         owner = p;
     }
+
+    public void reset() {
+        owner = null;
+    }
 }


### PR DESCRIPTION
## Summary
- add reset helpers to `Edge` and `Box` so they can clear their owners
- implement `DotsBoard.reset()` to iterate over edges and boxes, invoking the helpers

## Testing
- `javac -d out $(find src -name "*.java")`
- `jshell --class-path out <<'EOF'
import dots.*;
import game.Player;
DotsBoard board = new DotsBoard(3,3);
Player p = new Player("A");
board.claimAndScore(board.getEdge(0,0, Edge.Orient.H), p);
board.claimAndScore(board.getEdge(0,0, Edge.Orient.V), p);
board.claimAndScore(board.getEdge(0,1, Edge.Orient.V), p);
board.claimAndScore(board.getEdge(1,0, Edge.Orient.H), p);
board.reset();
System.out.println(board.getEdge(0,0, Edge.Orient.H).isFree());
System.out.println(board.getBox(0,0).hasOwner());
/exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68e1e76661548333a73337d72006e895